### PR TITLE
test production code paths

### DIFF
--- a/spec/factories/credential_factory.rb
+++ b/spec/factories/credential_factory.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     project_ids { workflows.map(&:project_id).uniq }
 
     after(:build) do |credential, evaluator|
-      credential.instance_variable_set(:@admin, evaluator.admin)
       credential.instance_variable_set(:@login, evaluator.login)
       credential.instance_variable_set(:@logged_in, evaluator.logged_in)
       credential.instance_variable_set(:@user_id, evaluator.user_id)

--- a/spec/policies/data_request_policy_spec.rb
+++ b/spec/policies/data_request_policy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe DataRequestPolicy do
     end
 
     it 'returns all records for an admin' do
-      credential = build(:credential, :admin, project_ids: [])
+      credential = fake_credential(admin: true, project_ids: [])
       expect(records_for(credential)).to match_array(DataRequest.all)
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.include FakeSession, type: :controller
+  config.include FakeSession
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/fake_session.rb
+++ b/spec/support/fake_session.rb
@@ -1,13 +1,18 @@
 module FakeSession
   def fake_session(admin: false, logged_in: true, project_ids: [], user_id: nil, expired: false)
-    @credential = instance_double(Credential,
-                                  authenticate!: logged_in,
-                                  logged_in?: logged_in,
-                                  admin?: admin,
-                                  expired?: expired,
-                                  user_id: user_id,
-                                  project_ids: project_ids)
+    credential = fake_credential(admin, logged_in, project_ids, user_id)
+    allow(controller).to receive(:credential).and_return(credential)
+  end
 
-    allow(controller).to receive(:credential).and_return(@credential)
+  def fake_credential(admin: false, logged_in: true, project_ids: [], user_id: nil, expired: false)
+    instance_double(
+      Credential,
+      authenticate!: logged_in,
+      logged_in?: logged_in,
+      admin?: admin,
+      expired?: expired,
+      user_id: user_id,
+      project_ids: project_ids
+    )
   end
 end


### PR DESCRIPTION
Move from factory traits to injecting instance doubles to clean up the factories and credential code. 

This way uses fake credential instance doubles instead of factory traits (instance method overrides) to ensure testing of the code paths in production code, not test env branches.

I think you can use this implementation vs the @instance variable code branching to address my PR concerns.